### PR TITLE
Hide local path buttons when section collapsed

### DIFF
--- a/web_interface.py
+++ b/web_interface.py
@@ -552,12 +552,11 @@ async def main_page():
                         </select>
                     </div>
                 </div>
-            </div>
-
-            <div class="form-group">
-                <button class="btn btn-secondary" onclick="testPath()">🔍 Test Path</button>
-                <button class="btn btn-primary" onclick="saveConfig()">💾 Save Configuration</button>
-                <button class="btn btn-secondary" onclick="loadStatus()">🔄 Refresh Status</button>
+                <div class="form-group">
+                    <button class="btn btn-secondary" onclick="testPath()">🔍 Test Path</button>
+                    <button class="btn btn-primary" onclick="saveConfig()">💾 Save Configuration</button>
+                    <button class="btn btn-secondary" onclick="loadStatus()">🔄 Refresh Status</button>
+                </div>
             </div>
 
             <button type="button" class="collapsible">🌐 GitLab Repository Configuration</button>


### PR DESCRIPTION
## Summary
- Hide Local Developer Folder Path buttons when section is collapsed

## Testing
- `python -m py_compile web_interface.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6c4da7b3c8327aad57d53bae9651a