### PR TITLE
Improve GitLab error handling

### DIFF
--- a/monitoring_service.py
+++ b/monitoring_service.py
@@ -421,7 +421,11 @@ class PatchWatchMonitoringService:
             response = requests.get(api_url, headers=headers)
             
             if response.status_code == 200:
-                user_info = response.json()
+                try:
+                    user_info = response.json()
+                except json.JSONDecodeError:
+                    self.logger.error(f"❌ Неверный ответ от GitLab при проверке токена: {response.text[:100]}")
+                    return False
                 self.logger.info(f"👤 Пользователь: {user_info.get('name')} ({user_info.get('username')})")
                 self.logger.info(f"🔑 Уровень доступа: {user_info.get('access_level', 'Unknown')}")
                 return True
@@ -444,7 +448,11 @@ class PatchWatchMonitoringService:
             response = requests.get(api_url, headers=headers, params=params)
             
             if response.status_code == 200:
-                projects = response.json()
+                try:
+                    projects = response.json()
+                except json.JSONDecodeError:
+                    self.logger.error(f"❌ Неверный JSON от GitLab при поиске проектов: {response.text[:100]}")
+                    return None
                 self.logger.info(f"🔍 Найдено проектов: {len(projects)}")
                 
                 for project in projects:
@@ -505,7 +513,11 @@ class PatchWatchMonitoringService:
             project_response = requests.get(project_api_url, headers=headers)
             
             if project_response.status_code == 200:
-                project_info = project_response.json()
+                try:
+                    project_info = project_response.json()
+                except json.JSONDecodeError:
+                    self.logger.error(f"❌ Неверный JSON при получении данных проекта: {project_response.text[:100]}")
+                    return False
                 permissions = project_info.get('permissions', {})
                 project_access = permissions.get('project_access') or {}
                 group_access = permissions.get('group_access') or {}

--- a/web_interface.py
+++ b/web_interface.py
@@ -1080,7 +1080,14 @@ async def test_gitlab_connection(request: dict):
         response = requests.get(api_url, headers=headers, timeout=10)
         
         if response.status_code == 200:
-            user_info = response.json()
+            try:
+                user_info = response.json()
+            except ValueError:
+                return JSONResponse({
+                    "success": False,
+                    "error": "Invalid JSON response from GitLab",
+                    "details": response.text[:100]
+                })
             return JSONResponse({
                 "success": True,
                 "user_name": user_info.get('name', 'Unknown'),


### PR DESCRIPTION
## Summary
- guard against invalid JSON responses in monitoring service
- handle malformed GitLab responses in web interface test endpoint

## Testing
- `python -m py_compile monitoring_service.py web_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e80923d083278ead924b8de3ad0c